### PR TITLE
Conform package.json license field to LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write '**/*.{js,css,json,md}'"
   },
   "author": "Sean W. Richardson <srichardson@cloudflare.com>",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "prettier": "^1.18.2"
   }


### PR DESCRIPTION
This brings the `license` field in `package.json` in line with the `LICENSE` file in the repository root.