### PR TITLE
Only allow GET requests to query ranges.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,8 @@ async function processRequest(request: Request): Promise<Response> {
     return response;
   }
 
-  if (request.method === 'POST') {
-    const response = new Response("Only GET requests can be used to query ranges, but this request used the POST verb", { "status": 405, "statusText": "Method Not Allowed" });
+  if (request.method !== 'GET') {
+    const response = new Response("Only GET requests can be used to query ranges, but this request used the " + request.method + " verb", { "status": 405, "statusText": "Method Not Allowed" });
     return response;
   }
 


### PR DESCRIPTION
This takes https://github.com/HaveIBeenPwned/PwnedPasswordsCloudflareWorker/commit/9baae8fff9ff30731e8321fe45d6575cbff89a35 a little further and prevents the use of any HTTP verb, except GET, to query ranges. 